### PR TITLE
Fix correct path for Books subset of MUSE.

### DIFF
--- a/configs/experiment/unlearn/muse/default.yaml
+++ b/configs/experiment/unlearn/muse/default.yaml
@@ -24,11 +24,14 @@ data:
       args:
         hf_args:
           split: ${forget_split}
+          path: muse-bench/MUSE-${data_split}
   retain:
     MUSE_retain:
       args:
         hf_args:
+          path: muse-bench/MUSE-${data_split}
           split: ${retain_split}
+
 
 eval:
   muse:

--- a/configs/experiment/unlearn/muse/scalability.yaml
+++ b/configs/experiment/unlearn/muse/scalability.yaml
@@ -23,11 +23,13 @@ data:
     MUSE_forget_scal: 
       args:
         hf_args:
+          path: muse-bench/MUSE-${data_split}
           split: ${forget_split}
   retain:
     MUSE_retain:
       args:
         hf_args:
+          path: muse-bench/MUSE-${data_split}
           split: ${retain_split}
 
 eval:

--- a/configs/experiment/unlearn/muse/sustainabilty.yaml
+++ b/configs/experiment/unlearn/muse/sustainabilty.yaml
@@ -23,11 +23,13 @@ data:
     MUSE_forget_sust: 
       args:
         hf_args:
+          path: muse-bench/MUSE-${data_split}
           split: ${forget_split}
   retain:
     MUSE_retain:
       args:
         hf_args:
+          path: muse-bench/MUSE-${data_split}
           split: ${retain_split}
 
 eval:


### PR DESCRIPTION
# What does this PR do?
Added correct path setting for the Books subset of MUSE. 
Previously, the News subset would always be loaded.

Fixes # 105


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Have you gone through the contributions [guide](../docs/contributing.md)?
- [ ] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).