### PR TITLE
Docs: Add "Unlearning Comparator" as a related resource for small-scale prototyping

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ For more in-depth information on specific aspects of the framework, refer to the
 | [`docs/links.md`](docs/links.md)             | List of all links to the research papers or other sources the implemented features are sourced from.              |
 | [`docs/repro.md`](docs/repro.md)            | Results are provided solely for reproducibility purposes, without any parameter tuning.             |
 ---
+## 🧩 Related Tools
+If you are new to unlearning or want to prototype on small-scale vision tasks first, try **[Unlearning Comparator](https://github.com/gnueaj/Machine-Unlearning-Comparator)** — an interactive system to visualize and compare unlearning methods. Insights gained here can be used to robustly scale up to the LLM-focused benchmarks in this repo.
 
 ## 🔗 Support & Contributors
 


### PR DESCRIPTION
Thank you for creating and maintaining this excellent repository. it’s a tremendous service to the community.

I’m the first author of the paper and system “Unlearning Comparator” (a visualization tool for comparing unlearning methods on  vision classification). Many researchers start by prototyping ideas in simpler setups before scaling to LLM-focused benchmarks; the tool is meant to support that first step.

Change summary:
If you are new to unlearning or want to prototype on small-scale vision tasks first, try [Unlearning Comparator](https://github.com/gnueaj/Machine-Unlearning-Comparator?utm_source=chatgpt.com)
 — an interactive system to visualize and compare unlearning methods. Insights gained here can be used to robustly scale up to the LLM-focused benchmarks in this repo.

Placement: 
under 📚 Further Documentation, directly below the table and above Support & Contributors.

Links:
Repo: [Machine-Unlearning-Comparator](https://github.com/gnueaj/Machine-Unlearning-Comparator)
Paper: [arXiv](https://arxiv.org/abs/2508.12730) under TVCG revision

I’ve kept the wording minimal and avoided listing it as a core component to respect the repo’s LLM scope. I’m happy to adjust the phrasing or placement if you prefer something different. 

Thank you for your consideration!

Best Regards,
Jaeung Lee