### PR TITLE
Fix ValueError: Assign retain set to eval in unlearn mode

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -56,6 +56,8 @@ def get_data(data_cfg: DictConfig, mode="train", **kwargs):
         return data
     elif mode == "unlearn":
         unlearn_splits = {k: v for k, v in data.items() if k not in ("eval", "test")}
+        if "retain" in unlearn_splits:
+            data["eval"] = unlearn_splits["retain"]
         unlearn_dataset = ForgetRetainDataset(**unlearn_splits, anchor=anchor)
         data["train"] = unlearn_dataset
         for split in unlearn_splits:


### PR DESCRIPTION
Add logic to retain evaluation data during unlearning.

# What does this PR do?
This PR fixes a `ValueError` that occurs when running the unlearning process with `eval_strategy="epoch"` or `"steps"`.

### Problem
Currently, in `src/data/__init__.py`, when `mode="unlearn"`, the code merges the splits into a single `train` dataset and then pops (removes) the original splits (including `retain`) from the `data` dictionary.
As a result, when the `Trainer` tries to access `eval_dataset` (typically the retain set), it finds `None`, causing the following error:
`ValueError: You have set args.eval_strategy to IntervalStrategy.EPOCH but you didn't pass an eval_dataset to Trainer.`

### Solution
I added logic to assign the `retain` split to `data["eval"]` before popping the splits. This ensures that the Trainer has access to evaluation data during the unlearning process.

Fixes # (issue)
N/A

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Have you gone through the contributions [guide](../docs/contributing.md)?
- [ ] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).