### PR TITLE
Fix compute_loss signature compatibility with transformers >= 4.46

### DIFF
--- a/src/trainer/unlearn/ceu.py
+++ b/src/trainer/unlearn/ceu.py
@@ -86,7 +86,7 @@ class CEU(UnlearnTrainer):
         super().__init__(*args, **kwargs)
         self.ignore_first_n_answer_tokens = ignore_first_n_answer_tokens
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
         loss, outputs = compute_batch_ceu(
             model,

--- a/src/trainer/unlearn/dpo.py
+++ b/src/trainer/unlearn/dpo.py
@@ -9,7 +9,7 @@ class DPO(GradDiff):
         if self.ref_model is None:
             self.ref_model = self._prepare_ref_model(self.model)
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]["original"]
         alternate_inputs = inputs["forget"]["alternate"]
 

--- a/src/trainer/unlearn/grad_ascent.py
+++ b/src/trainer/unlearn/grad_ascent.py
@@ -2,7 +2,7 @@ from trainer.unlearn.base import UnlearnTrainer
 
 
 class GradAscent(UnlearnTrainer):
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
         forget_inputs = {
             "input_ids": forget_inputs["input_ids"],

--- a/src/trainer/unlearn/grad_diff.py
+++ b/src/trainer/unlearn/grad_diff.py
@@ -38,7 +38,7 @@ class GradDiff(UnlearnTrainer):
             )
         return retain_loss
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
         forget_inputs = {
             "input_ids": forget_inputs["input_ids"],

--- a/src/trainer/unlearn/npo.py
+++ b/src/trainer/unlearn/npo.py
@@ -9,7 +9,7 @@ class NPO(GradDiff):
         if self.ref_model is None:
             self.ref_model = self._prepare_ref_model(self.model)
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
 
         forget_loss, forget_outputs = compute_dpo_loss(

--- a/src/trainer/unlearn/pdu.py
+++ b/src/trainer/unlearn/pdu.py
@@ -102,7 +102,7 @@ class PDU(GradDiff):
         )
         self.log({"retain_preference": self.preferences[1]})
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
         forget_inputs = {
             "input_ids": forget_inputs["input_ids"],

--- a/src/trainer/unlearn/rmu.py
+++ b/src/trainer/unlearn/rmu.py
@@ -136,7 +136,7 @@ class RMU(GradDiff):
             retain_loss = super().compute_retain_loss(model, retain_inputs)
         return retain_loss
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
         forget_inputs = {
             "input_ids": forget_inputs["input_ids"],

--- a/src/trainer/unlearn/satimp.py
+++ b/src/trainer/unlearn/satimp.py
@@ -14,7 +14,7 @@ class SatImp(GradDiff):
         if self.ref_model is None:
             self.ref_model = self._prepare_ref_model(self.model)
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
         forget_inputs = {
             "input_ids": forget_inputs["input_ids"],

--- a/src/trainer/unlearn/simnpo.py
+++ b/src/trainer/unlearn/simnpo.py
@@ -10,7 +10,7 @@ class SimNPO(GradDiff):
         self.delta = delta
         self.beta = beta
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
 
         forget_labels = forget_inputs["labels"]

--- a/src/trainer/unlearn/undial.py
+++ b/src/trainer/unlearn/undial.py
@@ -9,7 +9,7 @@ class UNDIAL(GradDiff):
         if self.ref_model is None:
             self.ref_model = self._prepare_ref_model(self.model)
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
         forget_loss, forget_outputs = compute_undial_loss(
             model, self.ref_model, forget_inputs, self.beta

--- a/src/trainer/unlearn/wga.py
+++ b/src/trainer/unlearn/wga.py
@@ -11,7 +11,7 @@ class WGA(GradDiff):
         if self.ref_model is None:
             self.ref_model = self._prepare_ref_model(self.model)
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         forget_inputs = inputs["forget"]
         forget_inputs = {
             "input_ids": forget_inputs["input_ids"],


### PR DESCRIPTION
# What does this PR do?
### Problem
The latest version of `transformers` (v4.46+) passes a new argument `num_items_in_batch` to the `compute_loss` method.
Currently, the custom trainers (`GradAscent`, etc.) do not accept arbitrary keyword arguments, causing a `TypeError` when running with recent `transformers` versions.

Error log:
`TypeError: GradAscent.compute_loss() got an unexpected keyword argument 'num_items_in_batch'`

### Solution
Added `**kwargs` to the `compute_loss` method signature in custom trainers to ensure compatibility with the latest `transformers` library.

Fixes # (issue)
N/A

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Have you gone through the contributions [guide](../docs/contributing.md)?
- [ ] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).