### PR TITLE
Fix BFloat16 compatibility in evaluation metrics

### DIFF
--- a/src/evals/metrics/utils.py
+++ b/src/evals/metrics/utils.py
@@ -95,8 +95,8 @@ def evaluate_probability(model, batch):
     avg_losses = losses / num_token_gt
     normalized_probs = torch.exp(-avg_losses)
 
-    avg_losses = avg_losses.cpu().numpy().tolist()
-    normalized_probs = normalized_probs.cpu().numpy().tolist()
+    avg_losses = avg_losses.float().cpu().numpy().tolist()
+    normalized_probs = normalized_probs.float().cpu().numpy().tolist()
     return [
         {"prob": prob, "avg_loss": avg_loss}
         for prob, avg_loss in zip(normalized_probs, avg_losses)


### PR DESCRIPTION
# What does this PR do?
### Problem
When evaluating models loaded in `bfloat16` precision (e.g., Llama-3 on Ampere+ GPUs), `avg_losses.cpu().numpy()` fails with `TypeError: Got unsupported ScalarType BFloat16` because NumPy does not support bfloat16 natively.

### Solution
Explicitly cast the tensor to `float32` using `.float()` before converting to NumPy in `src/evals/metrics/utils.py`.

Fixes # (issue)
N/A

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Have you gone through the contributions [guide](../docs/contributing.md)?
- [ ] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).