### PR TITLE
Remove duplicate log_softmax calculation

### DIFF
--- a/src/trainer/utils.py
+++ b/src/trainer/utils.py
@@ -19,7 +19,6 @@ def compute_kl_divergence(model, target_model, inputs):
         ref_outputs = target_model(**inputs)
 
     ref_probs = F.log_softmax(ref_outputs.logits, dim=-1)
-    ref_probs = F.log_softmax(ref_outputs.logits, dim=-1)
     ref_probs = ref_probs.view(-1, ref_outputs.logits.shape[-1])
 
     outputs = model(**inputs)


### PR DESCRIPTION
Removed duplicate log_softmax call on ref_outputs.

# What does this PR do?

Removed duplicate log_softmax call on ref_outputs.

Fixes # (issue)
[#135 ](https://github.com/locuslab/open-unlearning/issues/135)

## Before submitting
- [✔ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [✔ ] Have you gone through the contributions [guide](../docs/contributing.md)?
- [❌ ] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).