### PR TITLE
fix: complete the eval metrics Truth_Ratio calculation mentioned in the paper

### DIFF
--- a/configs/eval/tofu_metrics/forget_Truth_Ratio.yaml
+++ b/configs/eval/tofu_metrics/forget_Truth_Ratio.yaml
@@ -10,4 +10,4 @@ pre_compute:
     access_key: wrong
 
 handler: truth_ratio
-aggregator: prob_mean
+aggregator: closer_to_1_better

--- a/src/evals/metrics/memorization.py
+++ b/src/evals/metrics/memorization.py
@@ -118,21 +118,17 @@ def truth_ratio(model, **kwargs):
     # 1-tr is higher.
     def true_better(arr):
         return np.mean(np.maximum(0, 1 - arr))
-   
-   # NEW: Use correctness probability: correct / (correct + wrong), higher is better
+
+    # Extent of knowledge (as used in OpenUnlearning paper's meta-evaluation) uses tr=true/(true+false)
     def prob_mean(arr):
-        # arr here will be the new truth_ratios = correct / (correct + wrong)
         return np.mean(arr)
 
     if kwargs["aggregator"] == "closer_to_1_better":
-        use_original_ratio = True
         aggregator = closer_to_1_better
     elif kwargs["aggregator"] == "true_better":
-        use_original_ratio = True
         aggregator = true_better
     elif kwargs["aggregator"] == "prob_mean":
         aggregator = prob_mean
-        use_original_ratio = False
     else:
         raise ValueError(f"Invalid truth ratio aggregator: {kwargs['aggregator']}")
 
@@ -162,14 +158,14 @@ def truth_ratio(model, **kwargs):
 
     correct_prob = np.exp(-correct_avg_losses)
     wrong_prob = np.exp(-wrong_avg_losses)
-    
-    if use_original_ratio:
-        # Original definition: wrong / correct
+
+    if kwargs["aggregator"] != "prob_mean":
+        # Original definition from TOFU: wrong / correct
         truth_ratios = wrong_prob / (correct_prob + 1e-10)
     else:
-        # New definition: correct / (correct + wrong)
+        # New definition from OpenUnlearning: correct / (correct + wrong)
         truth_ratios = correct_prob / (correct_prob + wrong_prob + 1e-10)
-        
+
     value_by_index = dict(
         zip(correct_indices, [{"score": val} for val in truth_ratios])
     )


### PR DESCRIPTION
# What does this PR do?


Fixes #160

Now, the "aggregator" is expanded to three types: "closer_to_1_better", "true_better", "prob_mean".

You can modify the “aggregator” in the file "configs/eval/tofu_metrics/forget_Truth_Ratio.yaml" to change the method to calculate the Truth_Ratio.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Have you gone through the contributions [guide](../docs/contributing.md)?
- [x] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).