### PR TITLE
Fix pip install command for lm-eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ We provide several variants for each of the components in the unlearning pipelin
 # Environment setup
 conda create -n unlearning python=3.11
 conda activate unlearning
-pip install ".[lm_eval]"
+pip install ".[lm-eval]"
 pip install --no-build-isolation flash-attn==2.6.3
 
 # Data setup


### PR DESCRIPTION
# What does this PR do?
Currently we get:
```
WARNING: open-unlearning 0.1.0 does not provide the extra 'lm_eval'
```
because in setup.py it's called `lm-eval`.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Have you gone through the contributions [guide](../docs/contributing.md)?
- [ ] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).