### PR TITLE
Add missing .float() call to min_k++

### DIFF
--- a/src/evals/metrics/mia/min_k_plus_plus.py
+++ b/src/evals/metrics/mia/min_k_plus_plus.py
@@ -32,7 +32,7 @@ class MinKPlusPlusAttack(MinKProbAttack):
         sigma = torch.clamp(sigma, min=1e-6)
         scores = (
             target_prob.float().cpu().numpy() - mu.float().cpu().numpy()
-        ) / torch.sqrt(sigma).cpu().numpy()
+        ) / torch.sqrt(sigma).float().cpu().numpy()
 
         # Take bottom k% as the attack score
         num_k = max(1, int(len(scores) * self.k))


### PR DESCRIPTION
# What does this PR do?

Fixes issue where bfloat16 tensors would cause min_k++ evaluation to fail.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Have you gone through the contributions [guide](../docs/contributing.md)?
- [ ] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).